### PR TITLE
Removed Hacktoberfest tag

### DIFF
--- a/.github/issues_labeler.yml
+++ b/.github/issues_labeler.yml
@@ -16,5 +16,3 @@ Q-Sharp:
   - "(Q-Sharp|qsharp|Q#)"
 enhancement:
   - "(enhancement)"
-Hacktoberfest:
-  - "(.*)"


### PR DESCRIPTION
Updated Issue Labeler to stop adding Hacktoberfest tag to the new issues.