### PR TITLE
Hamiltonian Cycle added under Backtracking

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -227,6 +227,7 @@
 ## Backtracking
 
 - [Knight's Tour](backtracking/Knight's_Tour.py)
+- [Hamiltonian Cycle](backtracking/Hamiltonian_Cycle.py)
  
 ## Dynamic Programming
 

--- a/Python/backtracking/Hamiltonian_Cycle.py
+++ b/Python/backtracking/Hamiltonian_Cycle.py
@@ -1,0 +1,112 @@
+"""
+Hamiltonian Path: a Hamiltonian path (or traceable path) is a path
+    in an undirected or directed graph that visits each vertex exactly
+    once. A Hamiltonian cycle (or Hamiltonian circuit) is a Hamiltonian
+    path that is a cycle.
+
+Problem Link: https://en.wikipedia.org/wiki/Hamiltonian_path
+Purpose: To determine the existance of a Hamiltonian Cycle in the provided
+        undirected graph and return the path if such path exist.
+        The nodes are numbered from 1 to N
+Method : Backtracking
+
+Time Complexity:  O(2^N)
+Space Complexity: O(N)
+Argument : Graph (Dictionary)
+Return   : Hamiltonian Cycle (List)
+
+"""
+from collections import defaultdict
+
+
+def Move_next_node(n, graph, pos, ans):
+    # Base Case: If all the node is visited:
+    if pos == n:
+
+        # Check wether the last node and the first node are
+        # connected in order to form a Cycle
+        if ans[0] in graph[ans[-1]]:
+            return ans + [ans[0]]
+
+        return False
+
+    current = ans[-1]
+
+    # Check for each of the adjoining vertices
+    for i in graph[current]:
+
+        # Check wether the node is already visited or not
+        if i not in ans:
+            ans += [i]
+            temp = Move_next_node(n, graph, pos + 1, ans)
+            if temp:
+                return temp
+
+            ans.pop()
+
+    return False
+
+
+def Hamiltonial_Cycle(n, graph):
+    # To keep a track of already visited node and the answer
+    # We will start exploring the graph from Vertex 1
+    answer = [1]
+
+    # Start Exploring adjoining node/vertex
+    return Move_next_node(n, graph, 1, answer)
+
+
+# ------------------------DRIVER CODE ------------------------
+if __name__ == "__main__":
+    n, m = map(int, input("Enter the number of vertex and edges: ").split())
+    print("Enter the edges: ")
+    graph = defaultdict(list)
+    for i in range(m):
+        a, b = map(int, input().split())
+        graph[a] += [b]
+        graph[b] += [a]
+    ans = Hamiltonial_Cycle(n, graph)
+    if not ans:
+        print("Hamiltonian Cycle is not possible in the Given graph")
+    else:
+        print("Hamiltonian Cycle is possible in the graph")
+        print("The path is : ", *ans)
+
+"""
+Sample Input / Output
+
+     5----1------2
+    /\     \    /
+   /  \     \  /
+  /    \     \/
+ 3------6-----4
+
+Enter the number of vertex and edges: 6 8
+Enter the edges
+5 1
+1 2
+1 4
+5 6
+6 4
+4 2
+3 6
+5 3
+Hamiltonian Cycle is possible in the graph
+The path is :  1 5 3 6 4 2 1
+
+     5----1------2
+     \     \
+      \     \
+       \     \
+ 3------6-----4
+
+Enter the number of vertex and edges: 6 6
+Enter the edges:
+5 1
+3 6
+6 4
+1 2
+5 6
+1 4
+Hamiltonian Cycle is not possible in the Given graph
+"""


### PR DESCRIPTION
### Have you read the [Contributing Guidelines on Pull Requests](https://github.com/TesseractCoding/NeoAlgo/blob/master/CONTRIBUTING.md#pull-requests)?

YES

### Description

As assigned by @shraddhavp for issue #1475, I have added Hamiltonian Cycle under Backtracking.
The basic intuition behind the solution is starting from the first Node/Vertex (i.e Vertex 1) and moving to all the adjacent vertices one by one if the vertex is not already visited. we will continue this until all the vertices are visited ( Return the answer) or if there is no possible way to proceed further ( then we backtrack to previous node/vertex).

Problem Link:- [Hamiltonian Cycle/Path](https://en.wikipedia.org/wiki/Hamiltonian_path)

### Checklist

- [x] I've read the contribution guidelines.
- [x] I've checked the issue list before deciding what to submit.
- [x] I've edited the `README.md` and link to my code.

## Related Issues or Pull Requests

Issue:- #1475 
PR:- #1504 #1505 

I request @iamrajiv @atarax665 and @HarshCasper to review this PR and other related PR's form this issue