### PR TITLE
Prefix Sum of Array in C

### DIFF
--- a/C/README.md
+++ b/C/README.md
@@ -27,6 +27,7 @@
 - [Count of distinct elements in every window](cp/Count_Distinct_Elements_in_Every_Window.c)
 - [Longest substring without repeating characters](cp/Longest_substring_without_repeating_chars.cpp)
 - [Maximum Sum Subarray](cp/max_sum_subarray.c)
+- [Prefix Sum of Array](cp/prefix_sum.c)
 - [Knutt Morris Prat](cp/Knutt_Morris_Prat.c)
 - [Catalan Number](cp/catalan_number.c)
 - [Z Algorithm](cp/zalgorithm.c)

--- a/C/cp/prefix_sum.c
+++ b/C/cp/prefix_sum.c
@@ -1,0 +1,54 @@
+/*
+Given an array of N elements , find it's prefix sum array. In Competitive Programming, many times we need to calculate prefix sum array to solve our problem.
+*/
+
+#include <stdio.h>
+
+void prefix_sum_array(int ar[] ,int N)
+{
+    int pref_ar[N + 1];
+    pref_ar[0] = ar[0];
+    int i = 0;
+    /* we will add the current element of ar[] array
+    and previous element of pref_ar [] array */
+    for(i = 1; i < N; i++)
+    {
+        pref_ar[i] = ar[i] + pref_ar[i - 1];
+    }
+    printf("The New Prefix sum array is \n");
+    for(int i = 0; i < N; i++)
+    {
+        printf("%d ",pref_ar[i] );
+    }
+    printf("\n");
+    return;
+}
+
+int main()
+{
+    printf("Input array size\n");
+    int N;
+    scanf("%d", &N);
+    int ar[N + 1];
+    printf("Enter array elements \n");
+    for(int i = 0; i < N; i++)
+    {
+        scanf("%d", &ar[i]);
+    }
+    prefix_sum_array(ar , N);
+}
+/*
+Standard Input and Output
+
+Input array size
+7
+Enter array elements
+10 4 16 34 23 5 90
+
+The New Prefix sum array is
+10 14 30 64 87 92 182
+
+Time Complexity : O(N)
+Space Complexity : O(N)
+
+*/

--- a/C/cp/prefix_sum.c
+++ b/C/cp/prefix_sum.c
@@ -26,7 +26,7 @@ void prefix_sum_array(int ar[] ,int N)
 
 int main()
 {
-    printf("Input array size\n");
+    printf("Enter the size of array \n");
     int N;
     scanf("%d", &N);
     int ar[N + 1];
@@ -40,7 +40,7 @@ int main()
 /*
 Standard Input and Output
 
-Input array size
+Enter the size of array 
 7
 Enter array elements
 10 4 16 34 23 5 90


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.
You can learn more about contributing to NeoAlgo here: https://github.com/TesseractCoding/NeoAlgo/blob/master/CONTRIBUTING.md

Happy Contributing!

-->

### Have you read the [Contributing Guidelines on Pull Requests](https://github.com/TesseractCoding/NeoAlgo/blob/master/CONTRIBUTING.md#pull-requests)?

YES.

### Description

Given an array of N elements , find it's prefix sum array. In Competitive Programming, many times we need to calculate prefix sum array to solve our problem.

### Checklist

- [x] I've read the contribution guidelines.
- [x] I've checked the issue list before deciding what to submit.
- [x] I've edited the `README.md` and link to my code.

## Related Issues or Pull Requests

Fixes #4040
