### PR TITLE
fix: update chat link

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ You can find our Code of Conduct [here](/CODE_OF_CONDUCT.md).
 
 This project follows the [MIT License](/LICENSE).
 
-## Slack
+## Chat
 
-[![Slack](https://img.shields.io/badge/chat-on_slack-purple.svg?style=for-the-badge&logo=slack)](https://join.slack.com/t/tesseractcodi-bxq5968/shared_invite/zt-ju6c0nqq-KgkTvFyxjNVbDRBIjADanw)
+[![Discord](https://img.shields.io/discord/829038891611717753?color=7389DA&label=Discord&logo=Discord&logoColor=FFF&style=for-the-badge)](https://discord.com/invite/nUGcHHMy26)


### PR DESCRIPTION
- Removed link to inactive Slack channel 
- Replaced with invite link to Discord server 
- Shield updated with Discord logo/color as well.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.
You can learn more about contributing to NeoAlgo here: https://github.com/TesseractCoding/NeoAlgo/blob/master/CONTRIBUTING.md

Happy Contributing!

-->

### Have you read the [Contributing Guidelines on Pull Requests](https://github.com/TesseractCoding/NeoAlgo/blob/master/CONTRIBUTING.md#pull-requests)?

Y

### Description

There was an old button to an inactive Slack. I updated it to point to Discord invite.

### Checklist

- [X] I've read the contribution guidelines.
- [X] I've checked the issue list before deciding what to submit.
- [X] I've edited the `README.md` and link to my code.

## Related Issues or Pull Requests

N/A not related to an existing issue. I saw the link was outdated (the slack is no longer active). So I updated it for people who find this on Github and want to join the conversation.
