### PR TITLE
Greets while closing an issue or pull request

### DIFF
--- a/.github/workflows/auto_close_greeting.yml
+++ b/.github/workflows/auto_close_greeting.yml
@@ -1,0 +1,18 @@
+#new labels will be created while closing some issue so create a label for 'closed', 'expired'
+name: Greetings
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: Manoj-Paramsetti/Greeting-action@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: 'Thank you for taking out your time to raise an issue.<br>This issue is closed by ${{github.actor}}'
+        PR_message: 'Thank you for taking out your time and contributing to our project.<br>This pull request is closed by ${{github.actor}}'


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.
You can learn more about contributing to NeoAlgo here: https://github.com/TesseractCoding/NeoAlgo/blob/master/CONTRIBUTING.md

Happy Contributing!

-->

### Have you read the [Contributing Guidelines on Pull Requests](https://github.com/TesseractCoding/NeoAlgo/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

### Description

I have added a new feature. Which can send the greetings when closing the issue/pull request
#### Note: In this feature, two labels will be added:
> expired
> closed
#### Give a nice color for that :smiley_cat: 

### Checklist

- [x] I've read the contribution guidelines.
- [x] I've checked the issue list before deciding what to submit.
- [ ] I've edited the `README.md` and link to my code.

## Related Issues or Pull Requests

#5873 